### PR TITLE
Joko 61 mejoras visuales login

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -123,6 +123,7 @@ function Sidebar({ selectedModule, setSelectedModule, classes }: {
           <Image
             src={logoJoko}
             alt="Joko Logo"
+            priority={true}
           />
         </Link>
         <ul className="w-full px-4">

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -49,7 +49,7 @@ export default function Login() {
                             <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required placeholder="**********"></input>
                         </label>
-                        <div className="min-w-full flex justify-around"> 
+                        <div className="min-w-full flex justify-between"> 
                             <label className="flex items-center hover:cursor-pointer text-gray-600"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
                                 <input type="checkbox" className="mr-1 p-0 accent-lila hover:"></input>Recordarme 
                             </label>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -36,7 +36,7 @@ export default function Login() {
 //Pagina de login para los usuarios.
     return (
         <>
-            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 selection:bg-lila selection:text-white max-md:grid-cols-1">
+            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl">
                         <Image src={logoJoko} alt="Joko logo"></Image>
@@ -55,7 +55,7 @@ export default function Login() {
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 
                         </div>
-                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500 focus:cursor-wait">Iniciar</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 mt-2 min-w-full hover:bg-violet-500 focus:cursor-wait">Iniciar</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -42,11 +42,11 @@ export default function Login() {
                         <Image src={logoJoko} alt="Joko logo"></Image>
                         <h1 className="text-2xl font-black">Inicie sesion</h1>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su email:
-                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
+                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su contraseña: 
-                            <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
+                            <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
                             required placeholder="**********"></input>
                         </label>
                         <div className="min-w-full flex justify-between"> 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -51,7 +51,7 @@ export default function Login() {
                         </label>
                         <div className="min-w-full flex justify-between"> 
                             <label className="flex items-center hover:cursor-pointer text-gray-600"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
-                                <input type="checkbox" className="mr-1 p-0 accent-lila hover:"></input>Recordarme 
+                                <input type="checkbox" className="mr-2 p-0 accent-lila hover:"></input>Recordarme 
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 
                         </div>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -55,7 +55,7 @@ export default function Login() {
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 
                         </div>
-                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full">Iniciar</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500">Iniciar</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -38,11 +38,9 @@ export default function Login() {
         <>
             <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 bg-neutral-150 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
-                    <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col justify-center items-center p-6 gap-4 rounded-3xl">
-                        <LogIn size={150} color="#4f46e5" className=" hover:cursor-pointer"></LogIn>
-                        <h1 className="text-3xl font-black">
-                            Inicie sesion
-                        </h1>
+                    <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl">
+                        <LogIn size={150} color="#4f46e5" className="hover:cursor-pointer"></LogIn>
+                        <h1 className="text-2xl font-black">Inicie sesion</h1>
                         <label className="min-w-full pt-2 pb-2">Introduzca su email:
                             <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
                             required placeholder="ejemplo@ejemplo.com"></input>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -36,7 +36,7 @@ export default function Login() {
 //Pagina de login para los usuarios.
     return (
         <>
-            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 bg-neutral-150 selection:bg-lila selection:text-white max-md:grid-cols-1">
+            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl">
                         <LogIn size={150} color="#4f46e5" className="hover:cursor-pointer"></LogIn>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -50,7 +50,7 @@ export default function Login() {
                             required placeholder="**********"></input>
                         </label>
                         <div className="min-w-full flex justify-between"> 
-                            <label className="flex items-center hover:cursor-pointer text-gray-600"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
+                            <label className="flex items-center hover:cursor-pointer text-gray-400"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
                                 <input type="checkbox" className="mr-2 p-0 accent-lila hover:"></input>Recordarme 
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -41,15 +41,15 @@ export default function Login() {
                     <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl">
                         <LogIn size={150} color="#4f46e5" className="hover:cursor-pointer"></LogIn>
                         <h1 className="text-2xl font-black">Inicie sesion</h1>
-                        <label className="min-w-full pt-2 pb-2">Introduzca su email:
+                        <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su email:
                             <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
-                        <label className="min-w-full pt-2 pb-2">Introduzca su contraseña: 
+                        <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su contraseña: 
                             <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" required placeholder="**********"></input>
                         </label>
                         <div className="min-w-full flex justify-around"> 
-                            <label className="flex items-center hover:cursor-pointer"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
+                            <label className="flex items-center hover:cursor-pointer text-gray-600"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
                                 <input type="checkbox" className="mr-1 p-0 accent-lila hover:"></input>Recordarme 
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -39,7 +39,7 @@ export default function Login() {
             <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl">
-                        <Image src={logoJoko} alt="Joko logo"></Image>
+                        <Image src={logoJoko} alt="Joko logo" priority={true}></Image>
                         <h1 className="text-2xl font-black">Inicie sesion</h1>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su email:
                             <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 hover:border-lila" 
@@ -59,7 +59,7 @@ export default function Login() {
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">
-                    <Image src={imagen} className='max-h-screen min-h-full object-cover' alt="Imagen"></Image>
+                    <Image src={imagen} className='max-h-screen min-h-full object-cover' alt="Imagen" priority={true}></Image>
                 </div>
             </div>
         </>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -55,7 +55,7 @@ export default function Login() {
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 
                         </div>
-                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500">Iniciar</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500 focus:cursor-wait">Iniciar</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import Image from "next/image"
-import { LogIn } from "react-feather"
+import logoJoko from '../../public/images/logoJoko.png'
 import imagen from '../../public/images/modelo.jpg'
 import React, { useState } from "react"
 import { useRouter } from "next/router"
@@ -39,7 +39,7 @@ export default function Login() {
             <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} action="/" className=" min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl">
-                        <LogIn size={150} color="#4f46e5" className="hover:cursor-pointer"></LogIn>
+                        <Image src={logoJoko} alt="Joko logo"></Image>
                         <h1 className="text-2xl font-black">Inicie sesion</h1>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su email:
                             <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -42,11 +42,12 @@ export default function Login() {
                         <LogIn size={150} color="#4f46e5" className="hover:cursor-pointer"></LogIn>
                         <h1 className="text-2xl font-black">Inicie sesion</h1>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su email:
-                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
+                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su contraseña: 
-                            <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" required placeholder="**********"></input>
+                            <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
+                            required placeholder="**********"></input>
                         </label>
                         <div className="min-w-full flex justify-around"> 
                             <label className="flex items-center hover:cursor-pointer text-gray-600"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -42,16 +42,16 @@ export default function Login() {
                         <Image src={logoJoko} alt="Joko logo"></Image>
                         <h1 className="text-2xl font-black">Inicie sesion</h1>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su email:
-                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
+                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 hover:border-lila" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
                         <label className="min-w-full pt-2 pb-2 text-gray-600">Introduzca su contraseña: 
-                            <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
+                            <input onChange={handlePasswordChange} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 hover:border-lila" 
                             required placeholder="**********"></input>
                         </label>
                         <div className="min-w-full flex justify-between"> 
-                            <label className="flex items-center hover:cursor-pointer text-gray-400"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
-                                <input type="checkbox" className="mr-2 p-0 accent-lila hover:"></input>Recordarme 
+                            <label className="flex items-center hover:cursor-pointer text-gray-400 hover:text-lila"> {/* Accent-color creo que no soportan todos los navegadores, investigar */}
+                                <input type="checkbox" className="mr-2 p-0 accent-lila"></input>Recordarme 
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 
                         </div>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -55,7 +55,7 @@ export default function Login() {
                             </label>
                             <p className="hover:underline text-[#4f46e5]"><Link href="/signup">Registrarse</Link></p> 
                         </div>
-                        <button type="submit" className="bg-lila text-white rounded-2xl p-2 min-w-full">Iniciar</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full">Iniciar</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -46,7 +46,7 @@ export default function Signup() {
     //Pagina de registro para los usuarios.
     return ( 
         <>
-            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 bg-neutral-150 selection:bg-lila selection:text-white max-md:grid-cols-1">
+            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} className="min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl"> 
                         <UserPlus size={150} color="#4f46e5"></UserPlus>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -65,7 +65,7 @@ export default function Signup() {
                             <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
-                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full">Registrarme</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500">Registrarme</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -53,15 +53,15 @@ export default function Signup() {
                         <h1 className="text-2xl font-black">
                             Registrarse
                         </h1>
-                        <label className="min-w-full pt-1 pb-2">Introduzca su email:
+                        <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su email:
                             <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
-                        <label className="min-w-full pt-1 pb-2">Introduzca su contraseña: 
+                        <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su contraseña: 
                             <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
-                        <label className="min-w-full pt-1 pb-2">Confirmar contraseña: 
+                        <label className="min-w-full pt-1 pb-2 text-gray-600">Confirmar contraseña: 
                             <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import Image from "next/image"
-import imagen from '../../public/images/desk_image1.jpg'
+import imagen from '../../public/images/desk_image3.jpg'
 import logoJoko from '../../public/images/logoJoko.png'
 import { useRouter } from 'next/router'
 import {createUser } from "../utils/api"
@@ -46,7 +46,7 @@ export default function Signup() {
     //Pagina de registro para los usuarios.
     return ( 
         <>
-            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 selection:bg-lila selection:text-white max-md:grid-cols-1">
+            <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} className="min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl"> 
                         <Image src={logoJoko} alt="Joko logo"></Image>
@@ -65,7 +65,7 @@ export default function Signup() {
                             <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
-                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500 focus:cursor-wait">Registrarme</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 mt-1 min-w-full hover:bg-violet-500 focus:cursor-wait">Registrarme</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import Image from "next/image"
 import imagen from '../../public/images/desk_image1.jpg'
-import { UserPlus } from "react-feather"
+import logoJoko from '../../public/images/logoJoko.png'
 import { useRouter } from 'next/router'
 import {createUser } from "../utils/api"
 
@@ -49,7 +49,7 @@ export default function Signup() {
             <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} className="min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl"> 
-                        <UserPlus size={150} color="#4f46e5"></UserPlus>
+                        <Image src={logoJoko} alt="Joko logo"></Image>
                         <h1 className="text-2xl font-black">
                             Registrarse
                         </h1>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,4 +1,3 @@
-import Link from "next/link"
 import React, { useState } from "react"
 import Image from "next/image"
 import imagen from '../../public/images/desk_image1.jpg'
@@ -49,9 +48,9 @@ export default function Signup() {
         <>
             <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 gap-4 bg-neutral-150 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
-                    <form onSubmit={handleSubmit} className="min-h-full min-w-full flex flex-col justify-center items-center p-6 gap-4 rounded-3xl"> 
+                    <form onSubmit={handleSubmit} className="min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl"> 
                         <UserPlus size={150} color="#4f46e5"></UserPlus>
-                        <h1 className="text-3xl font-black">
+                        <h1 className="text-2xl font-black">
                             Registrarse
                         </h1>
                         <label className="min-w-full pt-1 pb-2">Introduzca su email:

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -65,7 +65,7 @@ export default function Signup() {
                             <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
-                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500">Registrarme</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full hover:bg-violet-500 focus:cursor-wait">Registrarme</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -49,7 +49,7 @@ export default function Signup() {
             <div className="min-h-screen min-w-full grid grid-flow-col grid-cols-2 selection:bg-lila selection:text-white max-md:grid-cols-1">
                 <div className="mx-auto my-auto flex flex-col justify-center items-center w-3/4 h-3/4">
                     <form onSubmit={handleSubmit} className="min-h-full min-w-full flex flex-col p-6 gap-4 rounded-3xl"> 
-                        <Image src={logoJoko} alt="Joko logo"></Image>
+                        <Image src={logoJoko} alt="Joko logo" priority={true}></Image>
                         <h1 className="text-2xl font-black">
                             Registrarse
                         </h1>
@@ -69,7 +69,7 @@ export default function Signup() {
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">
-                    <Image src={imagen} className='max-h-screen min-h-full object-cover' alt="Imagen"></Image>
+                    <Image src={imagen} className='max-h-screen min-h-full object-cover w-auto h-auto' alt="Imagen" priority={true}></Image>
                 </div>
             </div>
         </>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -54,15 +54,15 @@ export default function Signup() {
                             Registrarse
                         </h1>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su email:
-                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
+                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su contraseña: 
-                            <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
+                            <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Confirmar contraseña: 
-                            <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2" 
+                            <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
                         <button type="submit" className="bg-lila text-white rounded-2xl p-2 min-w-full">Registrarme</button>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -65,7 +65,7 @@ export default function Signup() {
                             <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
-                        <button type="submit" className="bg-lila text-white rounded-2xl p-2 min-w-full">Registrarme</button>
+                        <button type="submit" className="bg-lila text-white rounded-xl p-2 min-w-full">Registrarme</button>
                     </form>
                 </div>
                 <div className="min-h-full min-w-full flex items-center justify-center max-md:hidden">

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -54,15 +54,15 @@ export default function Signup() {
                             Registrarse
                         </h1>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su email:
-                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
+                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su contraseña: 
-                            <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
+                            <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Confirmar contraseña: 
-                            <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2" 
+                            <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
                         <button type="submit" className="bg-lila text-white rounded-xl p-2 mt-1 min-w-full hover:bg-violet-500 focus:cursor-wait">Registrarme</button>

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -54,15 +54,15 @@ export default function Signup() {
                             Registrarse
                         </h1>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su email:
-                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
+                            <input onChange={handleEmailChange} type="email" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 hover:border-lila" 
                             required placeholder="ejemplo@ejemplo.com"></input>
                         </label>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Introduzca su contraseña: 
-                            <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
+                            <input onChange={handlePassword1Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 hover:border-lila" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
                         <label className="min-w-full pt-1 pb-2 text-gray-600">Confirmar contraseña: 
-                            <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 focus:border-lila" 
+                            <input onChange={handlePassword2Change} type="password" className="block text-black min-w-full rounded-lg h-10 p-2 border-2 mt-2 hover:border-lila" 
                             required minLength={minimun} placeholder="**********"></input>
                         </label>
                         <button type="submit" className="bg-lila text-white rounded-xl p-2 mt-1 min-w-full hover:bg-violet-500 focus:cursor-wait">Registrarme</button>

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -17,7 +17,6 @@ export async function loginUser(data: {email: string, password: string}) {
         let responseJson = await response.json()
         //Validaciones para notificar al usuario
         if (response.ok) {
-            alert("Inicio de sesion exitoso")
             //para recuperar el access token y guardarlo en el storage del browser
             let token = responseJson.accessToken
             localStorage.setItem("accessToken", token) //guardo el access token en el storage del browser
@@ -54,7 +53,6 @@ export async function createUser(data: {email: string, password: string}) {
         let responseJson = await response.json()
         //Validaciones para notificar al usuario
         if (response.ok) {
-            alert("El usuario se registro con exito")
             //para recuperar el access token y guardarlo en el storage del browser
             let token = responseJson.accessToken
             localStorage.setItem("accessToken", token) //guardo el access token en el storage del browser

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,1 @@
 export const API_URL = process.env.NEXT_PUBLIC_API_URL
-export const API_USERS = process.env.NEXT_PUBLIC_API_USERS
-export const API_AUTH = process.env.NEXT_PUBLIC_API_AUTH


### PR DESCRIPTION
### Implementacion de incidencia JOKO-61 (mejoras visuales a /login y /signup)

- El título principal se alineo a la izquierda y se hizo mas pequeño (en /login y /signup)
- Los labels se cambiaron al color text-gray-600 (en /login y /signup)
- Se aumento la separación entre texto de labels e inputs  (en /login y /signup)
- Recordarme y Registrarse ahora con separación de justify-content: space-between en lugar de around
- Se aumento la separación entre el label Recordarme y checkbox (en /login)
- El texto de Recordarme se cambio al color  text-gray-400 (en /login)
- El fondo de toda la página se cambio a blanco en lugar del gris (en /login y /signup)
- El borde del boton enviar se redondeo con rounded-xl (en /login y /signup)
- El fondo del botón cambia de color cuando se hace un hover a un lila más claro (en /login y /signup)
- El icono ahora es de Joko (en /login y /signup)
- El botón tiene un indicador de loading cuando se oprime y está esperando que retorne la llamada del backend (en /login y /signup)
- Se quito el alert el inicio de sesión es exitoso o el registro (en /login y /signup)
- Se agregaron algunos hovers en los inputs
- Se quitaron algunas cosas innecesarias